### PR TITLE
chore: delete source not necessary to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
     "rewrites": [
         {
-            "source": "/(.*)",
-            "destination": "/"
-        },
-        {
             "source": "/api/mangadex/:path*",
             "destination": "https://api.mangadex.org/:path*"
         }


### PR DESCRIPTION
Se eliminó la línea de recursos generales para evitar inconvenientes al hacer solicitudes a la API de MangaDex en Vercel